### PR TITLE
Wrapper for terragrunt and terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+.idea/

--- a/wrappers/README.md
+++ b/wrappers/README.md
@@ -1,0 +1,91 @@
+# Wrapper for the root module
+
+The configuration in this directory contains an implementation of a single module wrapper pattern, which allows managing several copies of a module in places where using the native Terraform 0.13+ `for_each` feature is not feasible (e.g., with Terragrunt).
+
+You may want to use a single Terragrunt configuration file to manage multiple resources without duplicating `terragrunt.hcl` files for each copy of the same module.
+
+This wrapper does not implement any extra functionality. It just calls the module with the same input variables and outputs the same outputs.
+
+## Usage
+
+### Usage with Terragrunt
+
+`terragrunt.hcl`: 
+```hcl
+terraform {
+  source = "git::https://github.com/terraform-yacloud-modules/terraform-yandex-security-group//wrappers.git?ref=main"
+}
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+include "env" {
+  path = find_in_parent_folders("environment.hcl")
+}
+
+dependency "vpc" {
+  config_path = "${find_in_parent_folders("vpc")}"
+}
+
+locals {
+  any = ["0.0.0.0/0"]
+}
+
+inputs = {
+  defaults = {
+    vpc_id = dependency.vpc.outputs.vpc_id
+  }
+  items = {
+    web = {
+      description = "Web security group"
+      ingress_rules = {
+        http = {
+          protocol       = "TCP"
+          description    = "Allow HTTP traffic from the Internet"
+          port           = 80
+          v4_cidr_blocks = local.any
+        }
+        https = {
+          protocol       = "TCP"
+          description    = "Allow HTTPS traffic from the Internet"
+          port           = 443
+          v4_cidr_blocks = local.any
+        }
+      }
+    }
+  }
+}
+```
+
+### Usage with Terraform
+
+```hcl
+module "security-groups" {
+  source = "git::https://github.com/terraform-yacloud-modules/terraform-yandex-security-group//wrappers"
+  
+  defaults = {
+    vpc_id = "vpc-1234567890abcdef0"
+  }
+  
+  items = {
+    web = {
+      description = "Web security group"
+      ingress_rules = {
+        http = {
+          protocol       = "TCP"
+          description    = "Allow HTTP traffic from the Internet"
+          port           = 80
+          v4_cidr_blocks = ["0.0.0.0/0"]
+        }
+        https = {
+          protocol       = "TCP"
+          description    = "Allow HTTPS traffic from the Internet"
+          port           = 443
+          v4_cidr_blocks = ["0.0.0.0/0"]
+        }
+      }
+    }
+  }
+}
+```

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -1,0 +1,13 @@
+module "wrapper" {
+  source = "../"
+
+  for_each = var.items
+
+  folder_id     = try(each.value.folder_id, var.defaults.folder_id, null)
+  blank_name    = try(each.value.blank_name, var.defaults.blank_name, each.key)
+  description   = try(each.value.description, var.defaults.description, "")
+  labels        = try(each.value.labels, var.defaults.labels, {})
+  vpc_id        = try(each.value.vpc_id, var.defaults.vpc_id, null)
+  ingress_rules = try(each.value.ingress_rules, var.defaults.ingress_rules, {})
+  egress_rules  = try(each.value.egress_rules, var.defaults.egress_rules, {})
+}

--- a/wrappers/outputs.tf
+++ b/wrappers/outputs.tf
@@ -1,0 +1,5 @@
+output "security_groups" {
+  description = "Map of outputs of a wrapper."
+  value       = module.wrapper
+  # sensitive   = false
+}

--- a/wrappers/variables.tf
+++ b/wrappers/variables.tf
@@ -1,0 +1,11 @@
+variable "defaults" {
+  description = "Map of default values which will be used for each item."
+  type        = any
+  default     = {}
+}
+
+variable "items" {
+  description = "Maps of items to create a wrapper from. Values are passed through to the module."
+  type        = any
+  default     = {}
+}

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    yandex = {
+      source  = "yandex-cloud/yandex"
+      version = ">= 0.72.0"
+    }
+  }
+  required_version = ">= 1.3"
+}


### PR DESCRIPTION
This pull request introduces a new wrapper for the root module to facilitate managing multiple copies of a module, particularly in scenarios where using Terraform's native `for_each` feature is not feasible. The wrapper is designed to work with both Terragrunt and Terraform, and it simplifies the configuration process by using default values and input variables.

Key changes include:

### Documentation:
* Added a comprehensive `README.md` file that explains the purpose of the wrapper, its usage with Terragrunt and Terraform, and provides example configurations.

### Configuration Files:
* [`main.tf`](diffhunk://#diff-e25ea9feee9bc4d08eb2df67afb1a69c0e9bf07580cb1604c478fbc2f10491f2R1-R13): Implemented the wrapper module configuration, utilizing the `for_each` feature to handle multiple items and applying default values where necessary.
* [`outputs.tf`](diffhunk://#diff-ca0b2f5b3caca7fcfae558fcb052e1961d06a3c1c740ec3916676208fc37f500R1-R5): Added an output block to export the map of outputs from the wrapper module.
* [`variables.tf`](diffhunk://#diff-78d272b6e8f345f5d2d8aa4e55f992f2733b66659193f43612c1aafbff01ea5dR1-R11): Defined variables for default values and items to be passed to the wrapper module.
* [`versions.tf`](diffhunk://#diff-fae3f8474201a9b0d80bddf286620bea79cf6f17812af6702228377452ddc53dR1-R9): Specified the required provider versions for Terraform and Yandex.