### PR TITLE
Fix protocol

### DIFF
--- a/examples/from-to-port/main.tf
+++ b/examples/from-to-port/main.tf
@@ -33,7 +33,7 @@ module "sg" {
 
   ingress_rules = {
     "rule1" = {
-      protocol       = "tcp"
+      protocol       = "TCP"
       description    = "Allow TCP traffic from 0.0.0.0/0"
       from_port      = 0
       to_port        = 65535

--- a/examples/one-port/main.tf
+++ b/examples/one-port/main.tf
@@ -33,7 +33,7 @@ module "sg" {
 
   ingress_rules = {
     "rule1" = {
-      protocol       = "tcp"
+      protocol       = "TCP"
       description    = "Allow TCP traffic from 0.0.0.0/0"
       port           = 80
       v4_cidr_blocks = ["0.0.0.0/0"]


### PR DESCRIPTION
Fix error https://github.com/terraform-yacloud-modules/terraform-yandex-security-group/issues/58:
```
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to module.sg.yandex_vpc_security_group_rule.ingress["rule1"], provider "provider[\"registry.terraform.io/yandex-cloud/yandex\"]" produced
│ an unexpected new value: .protocol: was cty.StringVal("tcp"), but now cty.StringVal("TCP").
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```